### PR TITLE
CMake Refactor and LLVM Linking Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13.0)
 project(Tau
   VERSION 0.1.0
   DESCRIPTION "A strictly typed, compiled, general purpose programming language."
-  LANGUAGES C
+  LANGUAGES C CXX
 )
 
 # Include the CTest module and enable testing for the project.

--- a/LLVMConfig.cmake
+++ b/LLVMConfig.cmake
@@ -14,24 +14,26 @@ include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-# Map LLVM components to corresponding library names and store them in the _LLVM_LIBRARIES variable.
-llvm_map_components_to_libnames(_LLVM_LIBRARIES
-  support
-  core
-  irreader
-  executionengine
-  jitlink
-  mcjit
-  exegesisx86
-  x86targetmca
-  x86codegen
-  x86disassembler
-  x86asmparser
-  x86desc
-  x86info
-  passes
+# List of required LLVM components.
+set(TAU_LLVM_COMPONENTS
+    support
+    core
+    irreader
+    executionengine
+    jitlink
+    mcjit
+    exegesisx86
+    x86targetmca
+    x86codegen
+    x86disassembler
+    x86asmparser
+    x86desc
+    x86info
+    passes
 )
+set_property(GLOBAL PROPERTY TAU_LLVM_COMPONENTS_PROPERTY ${TAU_LLVM_COMPONENTS})
 
-# Store the list of LLVM libraries in a global property for later use.
-set_property(GLOBAL PROPERTY LLVM_LIBRARIES_PROPERTY ${_LLVM_LIBRARIES})
-message(VERBOSE "LLVM Libraries: ${_LLVM_LIBRARIES}")
+# If TAU_LLVM_SHARED is ON, LLVM shared library will be used for linking.
+# Otherwise, static libraries will be used.
+option(TAU_LLVM_SHARED "Link to LLVM shared library." OFF)
+message(VERBOSE "Use LLVM shared library: ${TAU_LLVM_SHARED}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,83 +6,21 @@ add_compile_options(${TAU_COMPILE_OPTIONS})
 get_property(TAU_COMPILE_DEFINITIONS GLOBAL PROPERTY TAU_COMPILE_DEFINITIONS_PROPERTY)
 add_compile_definitions(${TAU_COMPILE_DEFINITIONS})
 
-# Define static libraries for various modules/components within the project.
-file(GLOB_RECURSE TAU_LIB_COMPILER_FILES  ${PROJECT_SOURCE_DIR}/src/compiler/*c)
-file(GLOB_RECURSE TAU_LIB_AST_FILES       ${PROJECT_SOURCE_DIR}/src/ast/*.c)
-file(GLOB_RECURSE TAU_LIB_LEXER_FILES     ${PROJECT_SOURCE_DIR}/src/stages/lexer/*.c)
-file(GLOB_RECURSE TAU_LIB_PARSER_FILES    ${PROJECT_SOURCE_DIR}/src/stages/parser/*.c)
-file(GLOB_RECURSE TAU_LIB_ANALYSIS_FILES  ${PROJECT_SOURCE_DIR}/src/stages/analysis/*.c)
-file(GLOB_RECURSE TAU_LIB_CODEGEN_FILES   ${PROJECT_SOURCE_DIR}/src/stages/codegen/*.c)
-file(GLOB_RECURSE TAU_LIB_LINKER_FILES    ${PROJECT_SOURCE_DIR}/src/linker/*.c)
-
-add_library(TAU_LIB_MEMTRACE    STATIC ${PROJECT_SOURCE_DIR}/src/utils/memory/memtrace.c)
-add_library(TAU_LIB_ARENA       STATIC ${PROJECT_SOURCE_DIR}/src/utils/memory/arena.c)
-add_library(TAU_LIB_LIST        STATIC ${PROJECT_SOURCE_DIR}/src/utils/collections/list.c)
-add_library(TAU_LIB_QUEUE       STATIC ${PROJECT_SOURCE_DIR}/src/utils/collections/queue.c)
-add_library(TAU_LIB_SET         STATIC ${PROJECT_SOURCE_DIR}/src/utils/collections/set.c)
-add_library(TAU_LIB_STACK       STATIC ${PROJECT_SOURCE_DIR}/src/utils/collections/stack.c)
-add_library(TAU_LIB_VECTOR      STATIC ${PROJECT_SOURCE_DIR}/src/utils/collections/vector.c)
-add_library(TAU_LIB_ARGPARSE    STATIC ${PROJECT_SOURCE_DIR}/src/utils/io/argparse.c)
-add_library(TAU_LIB_COMMAND     STATIC ${PROJECT_SOURCE_DIR}/src/utils/io/command.c)
-add_library(TAU_LIB_FILE        STATIC ${PROJECT_SOURCE_DIR}/src/utils/io/file.c)
-add_library(TAU_LIB_LOG         STATIC ${PROJECT_SOURCE_DIR}/src/utils/io/log.c)
-add_library(TAU_LIB_PATH        STATIC ${PROJECT_SOURCE_DIR}/src/utils/io/path.c)
-add_library(TAU_LIB_HASH        STATIC ${PROJECT_SOURCE_DIR}/src/utils/hash.c)
-add_library(TAU_LIB_STR         STATIC ${PROJECT_SOURCE_DIR}/src/utils/str.c)
-add_library(TAU_LIB_STR_VIEW    STATIC ${PROJECT_SOURCE_DIR}/src/utils/str_view.c)
-add_library(TAU_LIB_TIMER       STATIC ${PROJECT_SOURCE_DIR}/src/utils/timer.c)
-add_library(TAU_LIB_CRUMB       STATIC ${PROJECT_SOURCE_DIR}/src/utils/crumb.c)
-add_library(TAU_LIB_DIAGNOSTICS STATIC ${PROJECT_SOURCE_DIR}/src/utils/diagnostics.c)
-add_library(TAU_LIB_ERROR       STATIC ${PROJECT_SOURCE_DIR}/src/utils/error.c)
-add_library(TAU_LIB_COMPILER    STATIC ${TAU_LIB_COMPILER_FILES})
-add_library(TAU_LIB_LLVM        STATIC ${PROJECT_SOURCE_DIR}/src/llvm.c)
-add_library(TAU_LIB_AST         STATIC ${TAU_LIB_AST_FILES})
-add_library(TAU_LIB_LEXER       STATIC ${TAU_LIB_LEXER_FILES})
-add_library(TAU_LIB_PARSER      STATIC ${TAU_LIB_PARSER_FILES})
-add_library(TAU_LIB_ANALYSIS    STATIC ${TAU_LIB_ANALYSIS_FILES})
-add_library(TAU_LIB_CODEGEN     STATIC ${TAU_LIB_CODEGEN_FILES})
-add_library(TAU_LIB_LINKER      STATIC ${TAU_LIB_LINKER_FILES})
-
-# Combine libraries into a single variable for easier linking later.
-set(TAU_LIBRARIES
-  TAU_LIB_MEMTRACE
-  TAU_LIB_ARENA
-  TAU_LIB_LIST
-  TAU_LIB_QUEUE
-  TAU_LIB_SET
-  TAU_LIB_STACK
-  TAU_LIB_VECTOR
-  TAU_LIB_ARGPARSE
-  TAU_LIB_COMMAND
-  TAU_LIB_FILE
-  TAU_LIB_LOG
-  TAU_LIB_PATH
-  TAU_LIB_HASH
-  TAU_LIB_STR
-  TAU_LIB_STR_VIEW
-  TAU_LIB_TIMER
-  TAU_LIB_CRUMB
-  TAU_LIB_DIAGNOSTICS
-  TAU_LIB_ERROR
-  TAU_LIB_COMPILER
-  TAU_LIB_LLVM
-  TAU_LIB_AST
-  TAU_LIB_LEXER
-  TAU_LIB_PARSER
-  TAU_LIB_ANALYSIS
-  TAU_LIB_CODEGEN
-  TAU_LIB_LINKER
-)
-
-# Store libraries in a global property for later use.
-set_property(GLOBAL PROPERTY TAU_LIBRARIES_PROPERTY ${TAU_LIBRARIES})
+# Define Tau static library to be reused by tests and other targets.
+file(GLOB_RECURSE TAU_SOURCE_FILES  ${PROJECT_SOURCE_DIR}/src/*.c)
+list(REMOVE_ITEM TAU_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/main.c)
+set_property(GLOBAL PROPERTY TAU_SOURCE_FILES_PROPERTY ${TAU_SOURCE_FILES})
+add_library(TAU_LIB STATIC ${TAU_SOURCE_FILES})
 
 # Define the main executable target for the compiler.
 add_executable(tauc ${PROJECT_SOURCE_DIR}/src/main.c)
 
+# Link Tau static library to the main executable.
+target_link_libraries(tauc PUBLIC TAU_LIB)
+
 # Retrieve LLVM libraries and link them to the main executable.
 get_property(LLVM_LIBRARIES GLOBAL PROPERTY LLVM_LIBRARIES_PROPERTY)
-target_link_libraries(tauc PUBLIC ${TAU_LIBRARIES} ${LLVM_LIBRARIES})
+target_link_libraries(tauc PUBLIC ${LLVM_LIBRARIES})
 
 # Install the main executable for both Debug and Release configurations.
 install(TARGETS tauc CONFIGURATIONS Debug Release)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,9 +18,14 @@ add_executable(tauc ${PROJECT_SOURCE_DIR}/src/main.c)
 # Link Tau static library to the main executable.
 target_link_libraries(tauc PUBLIC TAU_LIB)
 
-# Retrieve LLVM libraries and link them to the main executable.
-get_property(LLVM_LIBRARIES GLOBAL PROPERTY LLVM_LIBRARIES_PROPERTY)
-target_link_libraries(tauc PUBLIC ${LLVM_LIBRARIES})
+# Retrieve required LLVM components.
+get_property(TAU_LLVM_COMPONENTS GLOBAL PROPERTY TAU_LLVM_COMPONENTS_PROPERTY)
+
+if(TAU_LLVM_SHARED)
+    llvm_config(tauc USE_SHARED ${TAU_LLVM_COMPONENTS})
+else()
+    llvm_config(tauc ${TAU_LLVM_COMPONENTS})
+endif()
 
 # Install the main executable for both Debug and Release configurations.
 install(TARGETS tauc CONFIGURATIONS Debug Release)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,10 +6,6 @@ add_compile_options(${TAU_COMPILE_OPTIONS})
 get_property(TAU_COMPILE_DEFINITIONS GLOBAL PROPERTY TAU_COMPILE_DEFINITIONS_PROPERTY)
 add_compile_definitions(TAU_TEST ${TAU_COMPILE_DEFINITIONS})
 
-# Retrieve LLVM libraries and link them to later targets.
-get_property(LLVM_LIBRARIES GLOBAL PROPERTY LLVM_LIBRARIES_PROPERTY)
-link_libraries(${LLVM_LIBRARIES})
-
 # Link Tau static library to later targets.
 link_libraries(TAU_LIB)
 
@@ -29,6 +25,9 @@ set(TAU_TEST_NAMES
   COMMAND
 )
 
+# Retrieve required LLVM components.
+get_property(TAU_LLVM_COMPONENTS GLOBAL PROPERTY TAU_LLVM_COMPONENTS_PROPERTY)
+
 # Iterate over each name in `TAU_TEST_NAMES` to create an executable and a corresponding test.
 foreach(NAME IN ITEMS ${TAU_TEST_NAMES})
   string(TOLOWER ${NAME} NAME_LOWER)
@@ -37,5 +36,12 @@ foreach(NAME IN ITEMS ${TAU_TEST_NAMES})
   # Define an executable target, excluding it from the default build target and register it as a test.
   # The source file for each test is assumed to be located in the `test` directory.
   add_executable(${TARGET} ${PROJECT_SOURCE_DIR}/test/${NAME_LOWER}_test.c)
+
+  if(TAU_LLVM_SHARED)
+    llvm_config(${TARGET} USE_SHARED ${TAU_LLVM_COMPONENTS})
+  else()
+    llvm_config(${TARGET} ${TAU_LLVM_COMPONENTS})
+  endif()
+
   add_test(NAME ${TARGET} COMMAND ${TARGET})
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,10 +6,12 @@ add_compile_options(${TAU_COMPILE_OPTIONS})
 get_property(TAU_COMPILE_DEFINITIONS GLOBAL PROPERTY TAU_COMPILE_DEFINITIONS_PROPERTY)
 add_compile_definitions(TAU_TEST ${TAU_COMPILE_DEFINITIONS})
 
-# Retrieve Tau and LLVM libraries and link them to later targets.
-get_property(TAU_LIBRARIES GLOBAL PROPERTY TAU_LIBRARIES_PROPERTY)
+# Retrieve LLVM libraries and link them to later targets.
 get_property(LLVM_LIBRARIES GLOBAL PROPERTY LLVM_LIBRARIES_PROPERTY)
-link_libraries(${TAU_LIBRARIES} ${LLVM_LIBRARIES})
+link_libraries(${LLVM_LIBRARIES})
+
+# Link Tau static library to later targets.
+link_libraries(TAU_LIB)
 
 # Define test names corresponding to modules/components to be tested.
 set(TAU_TEST_NAMES


### PR DESCRIPTION
This PR improves the CMake build system by simplifying the library structure, fixing and adding flexibility in how LLVM is linked. The project now builds a single large static library instead of multiple smaller ones, reducing complexity. Additionally, a new CMake option, `TAU_LLVM_SHARED`, allows LLVM to be linked either statically (default) or dynamically, providing more control over dependencies.